### PR TITLE
PWL-366: Set subscription endDate to end of day

### DIFF
--- a/subscription/controls.py
+++ b/subscription/controls.py
@@ -178,7 +178,7 @@ class SubscriptionControl():
             subscription.partnerId = partnerObj
             subscription.partyId = partyObj
             subscription.startDate = now
-            subscription.endDate = now + timedelta(days=period)
+            subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
 
             transactionType = 'create'
             transactionStartDate = subscription.startDate
@@ -187,13 +187,13 @@ class SubscriptionControl():
             endDate = subscription.endDate
             if (endDate<now):
                 # case2: expired subscription
-                subscription.endDate = now + timedelta(days=period)
+                subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
                 transactionType = 'renew'
                 transactionStartDate = now
                 transactionEndDate = subscription.endDate
             else:
                 # case3: active subscription
-                subscription.endDate = endDate + timedelta(days=period)
+                subscription.endDate = (endDate + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
                 transactionType = 'renew'
                 transactionStartDate = endDate
                 transactionEndDate = subscription.endDate

--- a/subscription/controls.py
+++ b/subscription/controls.py
@@ -178,7 +178,8 @@ class SubscriptionControl():
             subscription.partnerId = partnerObj
             subscription.partyId = partyObj
             subscription.startDate = now
-            subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
+            # Second precision: MySQL DateTime without fractional seconds rounds .999999 to the next day.
+            subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=0)
 
             transactionType = 'create'
             transactionStartDate = subscription.startDate
@@ -187,13 +188,13 @@ class SubscriptionControl():
             endDate = subscription.endDate
             if (endDate<now):
                 # case2: expired subscription
-                subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
+                subscription.endDate = (now + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=0)
                 transactionType = 'renew'
                 transactionStartDate = now
                 transactionEndDate = subscription.endDate
             else:
                 # case3: active subscription
-                subscription.endDate = (endDate + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=999999)
+                subscription.endDate = (endDate + timedelta(days=period)).replace(hour=23, minute=59, second=59, microsecond=0)
                 transactionType = 'renew'
                 transactionStartDate = endDate
                 transactionEndDate = subscription.endDate


### PR DESCRIPTION
## Summary
- Reapply the PWL-366 fix from `origin/PWL-366` onto current `master`.
- In `SubscriptionControl.createOrUpdateSubscription`, set create/renew `endDate` to 23:59:59.999999 on the final day instead of the same wall-clock time as `now`.
- Prevents mid-day cutoffs because active access checks use `endDate > now`.

## Test plan
- [ ] Create a new subscription via the purchase/create path and confirm `endDate` is end-of-day on the computed last day
- [ ] Renew an expired subscription and confirm the new `endDate` is end-of-day
- [ ] Renew an active subscription and confirm the extended `endDate` is end-of-day
- [ ] Confirm a subscription remains active throughout the final calendar day (`endDate > now` until midnight)


Made with [Cursor](https://cursor.com)