### PR TITLE
TAIR3-890: make the ORCID free-unit grant atomic (fixes partial-write root cause)

### DIFF
--- a/subscription/controls.py
+++ b/subscription/controls.py
@@ -6,6 +6,7 @@ from dateutil.parser import parse
 import json
 import string
 from django.utils import timezone
+from django.db import transaction
 from partner.models import SubscriptionTerm, BucketType, Partner
 from authentication.models import Credential, OrcidCredentials, OrcidCreditTracking
 from subscription.models import *
@@ -124,34 +125,42 @@ class SubscriptionControl():
         except OrcidCreditTracking.DoesNotExist:
             pass
 
-        userBucketUsageSet = UserBucketUsage.objects.all().filter(partyId=partyId)
-        if len(userBucketUsageSet) == 0:
-            userBucketUsage = None
-        else:
-            userBucketUsage = userBucketUsageSet[0]
+        # Granting units and recording the grant must land together. These are two
+        # separate writes and ATOMIC_REQUESTS is off, so without an explicit
+        # transaction anything that interrupts the request in between (worker
+        # recycle, client disconnect) commits the units but loses the tracking row.
+        # The account then holds free units with nothing recording that it was
+        # granted, which is invisible until someone audits it. Both tables are
+        # InnoDB, so this is enforced. (TAIR3-890)
+        with transaction.atomic():
+            userBucketUsageSet = UserBucketUsage.objects.all().filter(partyId=partyId)
+            if len(userBucketUsageSet) == 0:
+                userBucketUsage = None
+            else:
+                userBucketUsage = userBucketUsageSet[0]
 
-        if userBucketUsage is None:
-            userBucketUsage = UserBucketUsage()
-            userBucketUsage.partyId = Party.objects.get(partyId=partyId)
-            userBucketUsage.partner_id = 'tair'
-            userBucketUsage.total_units = units
-            userBucketUsage.remaining_units = units
-            userBucketUsage.free_expiry_date = now + timedelta(days=365)
-            userBucketUsage.save()
-        else:
-            if userBucketUsage.free_expiry_date is not None and now < userBucketUsage.free_expiry_date:
-                raise Exception("Free usage units cannot be added until previous units expired.")
-            userBucketUsage.total_units += units
-            userBucketUsage.remaining_units += units
-            userBucketUsage.free_expiry_date = now + timedelta(days=365)
-            userBucketUsage.save()
+            if userBucketUsage is None:
+                userBucketUsage = UserBucketUsage()
+                userBucketUsage.partyId = Party.objects.get(partyId=partyId)
+                userBucketUsage.partner_id = 'tair'
+                userBucketUsage.total_units = units
+                userBucketUsage.remaining_units = units
+                userBucketUsage.free_expiry_date = now + timedelta(days=365)
+                userBucketUsage.save()
+            else:
+                if userBucketUsage.free_expiry_date is not None and now < userBucketUsage.free_expiry_date:
+                    raise Exception("Free usage units cannot be added until previous units expired.")
+                userBucketUsage.total_units += units
+                userBucketUsage.remaining_units += units
+                userBucketUsage.free_expiry_date = now + timedelta(days=365)
+                userBucketUsage.save()
 
-        # Record reissue date per ORCID so the same ORCID cannot get credits again on another account
-        reissue_date = now + timedelta(days=365)
-        OrcidCreditTracking.objects.update_or_create(
-            orcid_id=orcid_id,
-            defaults={'credit_reissue_date': reissue_date}
-        )
+            # Record reissue date per ORCID so the same ORCID cannot get credits again on another account
+            reissue_date = now + timedelta(days=365)
+            OrcidCreditTracking.objects.update_or_create(
+                orcid_id=orcid_id,
+                defaults={'credit_reissue_date': reissue_date}
+            )
         return userBucketUsage
     
     @staticmethod


### PR DESCRIPTION
## Summary
**TAIR3-890**: closes the root cause behind the "grant partially succeeded" accounts — the grant is not atomic.

`SubscriptionControl.createOrUpdateUserBucketUsage_Free()` does two independent writes:

1. `UserBucketUsage.save()` — the units
2. `OrcidCreditTracking.update_or_create()` — the record that the grant happened

`ATOMIC_REQUESTS` is `False` and Django autocommits, so each commits on its own. Anything that interrupts the request between them (mod_wsgi worker recycle, client disconnect) leaves **units granted with no tracking row** — invisible until audited, and invisible to the nightly replenish job too, since that keys on the tracking row.

## Production evidence
partyId **360603** linked their ORCID on **2026-04-24**:

```
07:44:54,399  linktoorcid?code=NeHtez         <- OAuth callback
07:44:56,458  /api/auth/process-orcid-code
07:44:56,714  AddFreeUsageUnits: 360603       <- grant view entered
07:44:56,833  /api/auth/profile               <- flow continued normally
```

Their `free_expiry_date` is `2027-04-24 07:44:56.714760` — the same instant as that log line, so **write 1 committed**. There is no `OrcidCreditTracking` row for their ORCID, and no exception was logged. Nothing in production code deletes tracking rows (only `scripts/testOrcidCreditTracking.py`, and only for its test ORCID). **7 accounts** are currently in this state.

## Change
Wrap both writes in `transaction.atomic()`. Verified both tables are **InnoDB** (`information_schema`), so the transaction is genuinely enforced rather than silently ignored as it would be on MyISAM. Django 1.8.4 supports `transaction.atomic()`.

Diffed with `-w`: the only substantive changes are the `from django.db import transaction` import and the `with` wrapper; the rest is re-indentation.

## Scope / relationship to the other PRs
- **This PR** — stops *new* partial writes (runtime grant path).
- **#131** — self-heals/backfills the accounts already affected (nightly script). Deliberately kept separate so the time-sensitive backfill isn't held up by review of a runtime change; different files, no conflict.
- **tair3#357** — stops the tair3 side from reporting success when the grant fails.

## Deliberately NOT included
The eligibility check (`OrcidCreditTracking.get` → "cannot be added until previous units expired") is still read-then-write without a row lock, so two concurrent `add_free` calls for the same account could both pass it and double-grant. I saw the OAuth callback processed twice in the logs above (`07:44:54` and `07:44:55`), so this isn't hypothetical — but no double-grant has actually been observed, and adding `select_for_update` semantics here is a separate behavioural change that deserves its own review. Flagging rather than folding it in silently.

## Risk: Low-Medium
Behaviour is unchanged on the success path; failures now roll back instead of half-committing. Touches the live grant path, so it should ride a normal release with a smoke test (link an ORCID on UAT, confirm units + tracking row both appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live ORCID free-grant path; success behavior is the same but failures now roll back both writes instead of leaving inconsistent state.
> 
> **Overview**
> **TAIR3-890** fixes partial commits on the ORCID free-credit path by making `SubscriptionControl.createOrUpdateUserBucketUsage_Free()` commit **both** the `UserBucketUsage` update and the `OrcidCreditTracking` row in one database transaction.
> 
> With `ATOMIC_REQUESTS` off, each `.save()` / `update_or_create()` used to autocommit separately, so a worker recycle or client disconnect between them could leave free units on the account with no tracking row (invisible to audits and nightly replenish). The grant logic is unchanged; it is only indented inside `with transaction.atomic():` so a failure or interruption rolls back both writes instead of half-committing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a114bd330aa9a9a34fe63ffb914df2fc8a982abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->